### PR TITLE
Parent optional

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,4 +303,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,7 +1,7 @@
 class Commit < ActiveRecord::Base
 
   belongs_to :project
-  belongs_to :parent, foreign_key: :parent_sha, primary_key: :sha, class_name: "Commit"
+  belongs_to :parent, foreign_key: :parent_sha, primary_key: :sha, class_name: "Commit", optional: true
   has_many :children, foreign_key: :parent_sha, primary_key: :sha, class_name: "Commit"
   has_and_belongs_to_many :committers, class_name: "User"
   has_and_belongs_to_many :pull_requests, class_name: "Github::PullRequest"


### PR DESCRIPTION
### Summary
In recent versions of Rails, `belongs_to` defaults to required, but a commit does not _always_ need a parent, at least as far as Houston needs be concerned.