### PR TITLE
Fixed compatibility with addressable >= 2.4

### DIFF
--- a/lib/houston/adapters/version_control/git_adapter.rb
+++ b/lib/houston/adapters/version_control/git_adapter.rb
@@ -74,6 +74,8 @@ module Houston
           SSH_PUBLICKEY = File.expand_path("~/.ssh/id_rsa.pub").freeze
 
           def local_path?(location)
+            return false if location.to_s =~ /@/ # If there's an @, then it's not local
+
             !Addressable::URI.parse(location.to_s).absolute?
           end
 


### PR DESCRIPTION
### Summary
Addressable starting in version 2.4 tries to parse `git@github.com:org/repo` as a URL, but fails, since `git@github.org` isn't a proper schema like `http` or `https`. 🤦 To avoid this crash, we can just test for a SSH-style location (which uses the `@`) when determining if a repo is local or remote.